### PR TITLE
Please can japid support a clean System.out

### DIFF
--- a/src.japid/cn/bran/japid/compiler/TranslateTemplateTask.java
+++ b/src.japid/cn/bran/japid/compiler/TranslateTemplateTask.java
@@ -1,4 +1,5 @@
 /**
+
  * Copyright 2010 Bing Ran<bing_ran@hotmail.com> 
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
@@ -21,6 +22,7 @@ import java.util.List;
 
 import cn.bran.japid.classmeta.AbstractTemplateClassMetaData;
 import cn.bran.japid.util.DirUtil;
+import cn.bran.japid.util.JapidFlags;
 
 /**
  * modeled after the JamonTask in the <a url = "http://www.jamon.org/>Jamon
@@ -47,7 +49,7 @@ import cn.bran.japid.util.DirUtil;
  * 
  */
 public class TranslateTemplateTask {
-
+	
 	private List<Class<?>> staticImports = new ArrayList<Class<?>>();
 	private List<String> imports = new ArrayList<String>();
 	// changed html source files
@@ -115,7 +117,7 @@ public class TranslateTemplateTask {
 		changedFiles = DirUtil.findChangedSrcFiles(include);
 
 		if (changedFiles.size() > 0) {
-			System.out.println("[Japid] Processing " + changedFiles.size() + " template" + (changedFiles.size() == 1 ? "" : "s") + " in directory tree: " + destDir);
+			if (JapidFlags.verbose) System.out.println("[Japid] Processing " + changedFiles.size() + " template" + (changedFiles.size() == 1 ? "" : "s") + " in directory tree: " + destDir);
 
 			JapidTemplateTransformer tran = new JapidTemplateTransformer(packageRoot.getPath(), null);
 			tran.usePlay(this.usePlay);
@@ -131,8 +133,8 @@ public class TranslateTemplateTask {
 
 			for (int i = 0; i < changedFiles.size(); i++) {
 				File templateFile = changedFiles.get(i);
-				System.out.println("[Japid] Transforming template: " + templateFile.getPath() + " to: " + DirUtil.mapSrcToJava(templateFile.getName()));
-				if (listFiles) {
+				if (JapidFlags.verbose) System.out.println("[Japid] Transforming template: " + templateFile.getPath() + " to: " + DirUtil.mapSrcToJava(templateFile.getName()));
+				if (JapidFlags.verbose && listFiles) {
 					System.out.println(templateFile.getAbsolutePath());
 				}
 

--- a/src.japid/cn/bran/japid/rendererloader/RendererCompiler.java
+++ b/src.japid/cn/bran/japid/rendererloader/RendererCompiler.java
@@ -22,6 +22,8 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 
+import cn.bran.japid.util.JapidFlags;
+
 
 /**
  * Java compiler (uses eclipse JDT)
@@ -267,7 +269,7 @@ public class RendererCompiler {
                         clazzName.append(compoundName[j]);
                     }
                     byte[] bytes = clazzFile.getBytes();
-                    System.out.println("[RenderCompiler]Compiled " + clazzName);
+                    if (JapidFlags.verbose) System.out.println("[RenderCompiler]Compiled " + clazzName);
                     // XXX address anonymous inner class issue!! ....$1...
                     String cname = clazzName.toString();
 					RendererClass rc = classes.get(cname);

--- a/src.japid/cn/bran/japid/rendererloader/TemplateClassLoader.java
+++ b/src.japid/cn/bran/japid/rendererloader/TemplateClassLoader.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import cn.bran.japid.template.JapidRenderer;
 import cn.bran.japid.template.JapidTemplateBaseWithoutPlay;
 import cn.bran.japid.template.RenderResult;
+import cn.bran.japid.util.JapidFlags;
 import cn.bran.japid.util.RenderInvokerUtils;
 
 /**
@@ -69,7 +70,7 @@ public class TemplateClassLoader extends ClassLoader {
 		rc.setClz(cl);
 		localClasses.put(name, cl);
 		rc.lastUpdated = 1;// System.currentTimeMillis();
-		System.out.println(oid + " reloaded from bytecode: " + name);
+		if (JapidFlags.verbose) System.out.println(oid + " reloaded from bytecode: " + name);
 		return cl;
 
 	}

--- a/src.japid/cn/bran/japid/template/JapidRenderer.java
+++ b/src.japid/cn/bran/japid/template/JapidRenderer.java
@@ -21,6 +21,7 @@ import cn.bran.japid.rendererloader.RendererClass;
 import cn.bran.japid.rendererloader.RendererCompiler;
 import cn.bran.japid.rendererloader.TemplateClassLoader;
 import cn.bran.japid.util.DirUtil;
+import cn.bran.japid.util.JapidFlags;
 import cn.bran.japid.util.StackTraceUtils;
 
 public class JapidRenderer {
@@ -229,7 +230,7 @@ public class JapidRenderer {
 	}
 
 	static void howlong(String string, long t) {
-		System.out.println(string + ":" + (System.currentTimeMillis() - t) + "ms");
+		if (JapidFlags.verbose) System.out.println(string + ":" + (System.currentTimeMillis() - t) + "ms");
 	}
 
 	/**
@@ -529,7 +530,7 @@ public class JapidRenderer {
 	}
 
 	static void log(String m) {
-		System.out.println("[JapidRender]: " + m);
+		if (JapidFlags.verbose) System.out.println("[JapidRender]: " + m);
 	}
 
 	static void gen() {

--- a/src.japid/cn/bran/japid/util/JapidFlags.java
+++ b/src.japid/cn/bran/japid/util/JapidFlags.java
@@ -1,0 +1,7 @@
+package cn.bran.japid.util;
+
+public class JapidFlags {
+
+	public static boolean verbose = false;
+
+}


### PR DESCRIPTION
Hi,

I'm trying to use Japid in a context where important data is written to System out. Unfortunately Japid also writes a bunch of internal diagnostics to System.out which get tangled with the real data.

Possibilities for addressing this include writing to System.err instead, using some sort of controllable logging, or (as in the example I am including here) simply making the output globally switchable.

Looking at the Japid codebase, I'm slightly worried that I might not have caught all writing to system out, particularly as the page class generation code seems to put System.out.println statements in the generated classes. I'd appreciate your take on whether this is something that Japid can do, or whether I would be better off with a different template system in this case.

Thanks,
Frank..
