### PR TITLE
使用CacheFor时发现的小bug

### DIFF
--- a/src.japidplay/cn/bran/play/RenderResultCache.java
+++ b/src.japidplay/cn/bran/play/RenderResultCache.java
@@ -92,7 +92,7 @@ public class RenderResultCache {
 	 * @param ttl
 	 */
 	public static void set(String key, RenderResult rr, String ttl) {
-		int tl = Time.parseDuration(ttl) * 1000;
+		long tl = Time.parseDuration(ttl) * 1000;
 		CachedItemStatus cachedItemStatus = new CachedItemStatus(tl);
 		cacheset(key, ttl, new CachedRenderResult(cachedItemStatus, rr));
 		// cacheTacker.put(key, cachedItemStatus);


### PR DESCRIPTION
在使用CacheFor时，默认是缓存30天，而30天换算成毫秒数时，超过了Integer的最大值。故将此处的int修改成long
