### PR TITLE
使用CacheFor时发现的小bug-补充

### DIFF
--- a/src.japidplay/cn/bran/play/RenderResultCache.java
+++ b/src.japidplay/cn/bran/play/RenderResultCache.java
@@ -92,7 +92,7 @@ public class RenderResultCache {
 	 * @param ttl
 	 */
 	public static void set(String key, RenderResult rr, String ttl) {
-		long tl = Time.parseDuration(ttl) * 1000;
+		long tl = Time.parseDuration(ttl) * 1000L;
 		CachedItemStatus cachedItemStatus = new CachedItemStatus(tl);
 		cacheset(key, ttl, new CachedRenderResult(cachedItemStatus, rr));
 		// cacheTacker.put(key, cachedItemStatus);


### PR DESCRIPTION
long a=int b \* int c 会先按照int去计算，然后再转换成long。
所以做出以下修改。
